### PR TITLE
WindowsConsoleSystemBrowser fix for .NET 6+

### DIFF
--- a/WindowsConsoleSystemBrowser/WindowsConsoleSystemBrowser/CallbackManager.cs
+++ b/WindowsConsoleSystemBrowser/WindowsConsoleSystemBrowser/CallbackManager.cs
@@ -30,13 +30,11 @@ namespace WindowsConsoleSystemBrowser
             }
         }
 
-        public async Task<string> RunServer(CancellationToken? token = null)
+        public async Task<string> RunServer(CancellationToken token = default(CancellationToken))
         {
-            token = CancellationToken.None;
-
             using (var server = new NamedPipeServerStream(_name, PipeDirection.In))
             {
-                await server.WaitForConnectionAsync(token.Value);
+                await server.WaitForConnectionAsync(token);
 
                 using (var sr = new StreamReader(server))
                 {

--- a/WindowsConsoleSystemBrowser/WindowsConsoleSystemBrowser/Program.cs
+++ b/WindowsConsoleSystemBrowser/WindowsConsoleSystemBrowser/Program.cs
@@ -79,7 +79,7 @@ namespace WindowsConsoleSystemBrowser
             var callbackManager = new CallbackManager(state.State);
 
             // open system browser to start authentication
-            Process.Start(state.StartUrl);
+            Process.Start(new ProcessStartInfo(state.StartUrl) { UseShellExecute = true });
 
             Console.WriteLine("Running callback manager");
             var response = await callbackManager.RunServer();

--- a/WindowsConsoleSystemBrowser/WindowsConsoleSystemBrowser/RegistryConfig.cs
+++ b/WindowsConsoleSystemBrowser/WindowsConsoleSystemBrowser/RegistryConfig.cs
@@ -32,7 +32,8 @@ namespace WindowsConsoleSystemBrowser
 
         const string CommandKeyValueName = "";
         const string CommandKeyValueFormat = "\"{0}\" \"%1\"";
-        static string CommandKeyValueValue => String.Format(CommandKeyValueFormat, Assembly.GetExecutingAssembly().Location);
+        static string CommandKeyValueValue => String.Format(
+            CommandKeyValueFormat, Assembly.GetExecutingAssembly().Location.Replace(".dll", ".exe"));
 
         const string UrlProtocolValueName = "URL Protocol";
         const string UrlProtocolValueValue = "";


### PR DESCRIPTION
1. After upgrading WindowsConsoleSystemBrowser to .NET 6/7, we are getting an exception at `Process.Start`: "The system cannot find the file specified'. To reproduce it, we need to change `<TargetFramework>net461</TargetFramework>` to `<TargetFramework>net6.0</TargetFramework>`. Microsoft [changed](https://learn.microsoft.com/en-us/dotnet/core/compatibility/fx-core) default value for ProcessStartInfo.UseShellExecute, so I fixed it by setting `true`.

2. The second issue in .NET 6 is that after clicking "Open" in the browser, we get "Could Not Load File Or Assembly 'System.Runtime, Version=6.0.0.0". For .NET 7 it shows Version=7.0.0.0. I don't know why that happens, but I figured out that we get that error when launching .dll instead of .exe in .NET6. So, I replaced .dll with .exe for the value in registry.

3. Fixed CancellationToken parameter in RunServer method as it always overwrites the parameter with CancellationToken.None

I've tested my changes in .NET Framework 4.6.1, .NET 6, and .NET 7